### PR TITLE
Feature/add git and shh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get install -y libpq-dev \
 
 RUN wget http://ftp.de.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u3_amd64.deb
 RUN dpkg -i libpng12-0_1.2.50-2+deb8u3_amd64.deb
+RUN rm libpng12-0_1.2.50-2+deb8u3_amd64.deb
 
 # Install Java 8
 RUN apt-get install -y openjdk-8-dbg
@@ -43,6 +44,7 @@ RUN apt-get install -y xdg-utils \
 
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg -i google-chrome-stable_current_amd64.deb
+RUN rm google-chrome-stable_current_amd64.deb
 
 # Install dockerise
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ ENV DOCKERIZE_VERSION v0.3.0
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-RUN apt-get update
+# Install git and ssh
+RUN apt-get update --fix-missing
+RUN apt-get install -y git \
+    openssh-server
+
 RUN apt-get install -y curl \
     wget \
     libssl-dev
@@ -49,4 +53,5 @@ RUN echo "nodeJs $(node -v)" \
   && echo "npm $(npm -v)" \
   && echo "yarn $(yarn -v)" \
   && java -version \
-  && google-chrome --version
+  && google-chrome --version \
+  && git --version

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Java, nodeJs, yarn, chrome and dockerize
+# Java, nodeJs, yarn, chrome, dockerize and git
 A docker file to support [data hub frontend](https://github.com/uktrade/data-hub-frontend/) with [data hub leeloo](https://github.com/uktrade/data-hub-leeloo/)
 This docker is based on [openjdk](https://github.com/docker-library/openjdk) and supports:
 
@@ -8,6 +8,7 @@ This docker is based on [openjdk](https://github.com/docker-library/openjdk) and
 - Yarn `1.0.2`
 - Google chrome `stable`
 - dockerize `v0.3.0`
+- git
 
 Intended for use in a [Circleci 2.0](https://circleci.com/) workflow
 


### PR DESCRIPTION
We have been seeing failures in CircleCi due to the base image (this repo) not having git or ssh installed on it. This meant that the following messages appeared on Circle When cloning the Data Hub repo:

![screen shot 2017-10-18 at 16 20 39](https://user-images.githubusercontent.com/2305016/31726985-58f11e20-b420-11e7-97ef-23660c1fac32.png)

This then caused the `service-deliveries` empty folder to appear in `src/app` of the checkout of data hub frontend on CircleCi boxes. (This folder and work was removed in [PR#777](https://github.com/uktrade/data-hub-frontend/pull/777))
This then caused the app to fail when using `yarn start` with the following error:

![screen shot 2017-10-18 at 16 20 20](https://user-images.githubusercontent.com/2305016/31727773-5b2c8a4c-b422-11e7-8598-f702dd537240.png)


The work in this PR installs `git` and `openssh` on this docker image so it no longer falls back to circelCi's git version

FYI @yeahfro 